### PR TITLE
fix: let extension use SharedArrayBuffer in chrome

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -26,6 +26,13 @@
     "https://youchoose.tracking.exposed/"
   ],
 
+  "cross_origin_embedder_policy": {
+    "value": "require-corp"
+  },
+  "cross_origin_opener_policy": {
+    "value": "same-origin"
+  },
+
   "background": {
     "scripts": ["./background.js"],
     "persistent": true


### PR DESCRIPTION
Two additional keys are required in the manifest for chrome
extensions to be able to use SharedArrayBuffer.

Slight issue though: the keys cause a warning in Firefox upon install,
because Firefox doesn't know these keys. But the extension
functions normally.

We may wanna consider having a system to produce different manifests
for different browsers in the future.