### PR TITLE
[WIP] feat: add eslint to the backend

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,7 +11,7 @@
       "jsx": true
     },
     "sourceType": "module",
-    "project": ["./tsconfig.paths.json"]
+    "project": ["./tsconfig.json"]
   },
   "plugins": ["@typescript-eslint", "react"],
   "env": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "prepare": "husky install",
     "clean": "rm -rf ./build ./dist",
-    "lint": "eslint ./src",
+    "lint": "eslint ./src ./yttrex-backend/backend",
     "format": "prettier -w ./src config-overrides.js",
     "tsc": "tsc",
     "build": "react-app-rewired build",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,11 +27,13 @@
     "skipLibCheck": true
   },
   "include": [
-    "./src"
+    "./src",
+    "./scripts",
+    "./yttrex-backend/backend"
   ],
   "exclude": [
     "node_modules",
-    "public",
-    "**/__tests__/**"
+    "**/public/**",
+    "**/build/**"
   ]
 }


### PR DESCRIPTION
As we are fine-tuning a lot of things right now and there are no longer huge pending PR's, I thought it might be a good time to introduce eslint to the backend.

By only linting the "backend" dir I only get 625 errors among which 122 are auto-fixable so this should not take long to fix.

I did not find a solution to include the .eslintrc in the backend repo yet.