### PR TITLE
fix: do not include corp keys in ff manifest

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -27,13 +27,6 @@
     "https://yt3.ggpht.com/"
   ],
 
-  "cross_origin_embedder_policy": {
-    "value": "require-corp"
-  },
-  "cross_origin_opener_policy": {
-    "value": "same-origin"
-  },
-
   "background": {
     "scripts": ["./background.js"],
     "persistent": true


### PR DESCRIPTION
the keys that are only needed for chrome are already being
added by config-overrides.js, they need to be removed from
the common manifest.json