### PR TITLE
fix: settings access token

### DIFF
--- a/src/components/dashboard/settings/AccessTokenBox.tsx
+++ b/src/components/dashboard/settings/AccessTokenBox.tsx
@@ -4,6 +4,7 @@ import {
   Button,
   FormControl,
   FormGroup,
+  FormHelperText,
   Grid,
   IconButton,
   Input,
@@ -16,6 +17,7 @@ import CloudDownload from '@material-ui/icons/CloudDownload';
 import VisibilityIcon from '@material-ui/icons/Visibility';
 import VisibilityOffIcon from '@material-ui/icons/VisibilityOff';
 import * as E from 'fp-ts/lib/Either';
+import { APIError } from 'providers/api.provider';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { assignAccessToken } from '../../../state/creator.commands';
@@ -39,6 +41,9 @@ export const AccessTokenBox: React.FC<AccessTokenBoxProps> = ({ profile }) => {
 
   const [token, setToken] = React.useState(profile?.accessToken ?? '');
   const [authTokenVisible, setAuthTokenVisible] = React.useState(token === '');
+  const [error, setError] = React.useState<
+    APIError | chrome.runtime.LastError | null
+  >(null);
 
   const classes = useStyles();
 
@@ -91,13 +96,16 @@ export const AccessTokenBox: React.FC<AccessTokenBoxProps> = ({ profile }) => {
                   ) : null
                 }
               />
+              {error !== null ? (
+                <FormHelperText error={true}>{error.message}</FormHelperText>
+              ) : null}
             </FormControl>
           </Grid>
           <Grid item xs={3}>
             {profile?.accessToken !== undefined ? (
               <Button
                 color="secondary"
-                variant="outlined"
+                variant="contained"
                 size="small"
                 startIcon={<CloudDownload />}
                 onClick={() => {
@@ -115,17 +123,24 @@ export const AccessTokenBox: React.FC<AccessTokenBoxProps> = ({ profile }) => {
         <Grid container spacing={2}>
           <Grid item>
             <Button
-              variant="outlined"
+              variant="contained"
               color="secondary"
               size="small"
               onClick={() => {
-                void assignAccessToken({ token })().then((c) => {
-                  if (E.isRight(c)) {
-                    if (c.right !== null) {
-                      setAuthTokenVisible(false);
+                setError(null);
+                if (authTokenVisible) {
+                  void assignAccessToken({ token })().then((c) => {
+                    if (E.isLeft(c)) {
+                      setError(c.left);
+                    } else if (E.isRight(c)) {
+                      if (c.right !== null) {
+                        setAuthTokenVisible(!authTokenVisible);
+                      }
                     }
-                  }
-                });
+                  });
+                } else {
+                  setAuthTokenVisible(true);
+                }
               }}
             >
               {t('actions:edit_access_token')}
@@ -134,13 +149,14 @@ export const AccessTokenBox: React.FC<AccessTokenBoxProps> = ({ profile }) => {
           <Grid item>
             {profile?.accessToken !== undefined ? (
               <Button
-                variant="outlined"
+                variant="contained"
                 color="primary"
                 size="small"
                 onClick={() => {
                   void deleteProfile({})().then(() => {
                     setToken('');
                     setAuthTokenVisible(true);
+                    setError(null);
                   });
                 }}
               >

--- a/src/state/creator.commands.ts
+++ b/src/state/creator.commands.ts
@@ -108,48 +108,49 @@ export const updateRecommendationForVideo = command(
 export const addRecommendationForVideo = command(
   ({
     videoId,
-    recommendationURL
+    recommendationURL,
   }: {
-    videoId: string
-    recommendationURL: string
+    videoId: string;
+    recommendationURL: string;
   }) =>
     pipe(
       profile.run(),
-      TE.chain((p) => sequenceS(TE.ApplicativePar)({
-        video: API.v3.Creator.OneCreatorVideo({
-          Headers: {
-            'x-authorization': p.accessToken,
-          },
-          Params: { videoId }
-        }),
-        recommendation: API.v3.Creator.CreateRecommendation({
-          Headers: {
-            'x-authorization': p.accessToken,
-          },
-          Body: { url: recommendationURL }
+      TE.chain((p) =>
+        sequenceS(TE.ApplicativePar)({
+          video: API.v3.Creator.OneCreatorVideo({
+            Headers: {
+              'x-authorization': p.accessToken,
+            },
+            Params: { videoId },
+          }),
+          recommendation: API.v3.Creator.CreateRecommendation({
+            Headers: {
+              'x-authorization': p.accessToken,
+            },
+            Body: { url: recommendationURL },
+          }),
         })
-      })),
-      TE.chain(({
-        video,
-        recommendation,
-      }) => {
+      ),
+      TE.chain(({ video, recommendation }) => {
         if (
           // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-          video.recommendations.includes(
-            recommendation.urlId
-          )
+          video.recommendations.includes(recommendation.urlId)
         ) {
           return TE.right(video);
         }
 
-        return updateRecommendationForVideo({
-          videoId,
-          recommendations: video.recommendations.concat(recommendation.urlId),
-        }, {
-          videoRecommendations: { videoId }
-        });
+        return updateRecommendationForVideo(
+          {
+            videoId,
+            recommendations: video.recommendations.concat(recommendation.urlId),
+          },
+          {
+            videoRecommendations: { videoId },
+          }
+        );
       })
-    ), {
+    ),
+  {
     videoRecommendations,
   }
 );
@@ -187,7 +188,7 @@ export const assignAccessToken = command(
         const isNotFoundError =
           e.message === 'Request failed with status code 500';
         if (isNotFoundError) {
-          return TE.right(null);
+          return TE.left({ message: 'The given access token is not valid.' });
         }
         return TE.left(e);
       }),


### PR DESCRIPTION
The user can now edit his own access token without deleting it first.
I also handled the error coming from the API when the token is invalid and displayed properly in the UI