### PR TITLE
fix: list all api with version in settings

### DIFF
--- a/src/components/dashboard/settings/APIList.tsx
+++ b/src/components/dashboard/settings/APIList.tsx
@@ -5,6 +5,7 @@ import {
   ListItem,
   ListItemText,
   Typography,
+  useTheme
 } from '@material-ui/core';
 import * as A from 'fp-ts/lib/Array';
 import { pipe } from 'fp-ts/lib/function';
@@ -16,41 +17,64 @@ import { config } from '../../../config';
 
 export const APIList: React.FC = () => {
   const { t } = useTranslation();
+  const theme = useTheme();
   return (
     <Box>
-      <Typography color="textPrimary" variant="h5">{t('settings:api_list_title')}</Typography>
+      <Typography color="textPrimary" variant="h5">
+        {t('settings:api_list_title')}
+      </Typography>
       {pipe(
-        Endpoints.v3,
+        Endpoints,
         R.toArray,
-        A.map(([key, routeEndpoints]) => {
+        A.map(([apiVersionKey, apiVersionEndpoints]) => {
           return (
-            <Box key={key}>
-              <Typography color="primary" variant="h6">{key}</Typography>
-              <List>
-                {pipe(
-                  routeEndpoints as { [key: string]: MinimalEndpointInstance },
-                  R.toArray,
-                  A.map(([routeName, endpoint]) => {
-                    const params = pipe(
-                      endpoint.Input?.Params?.props ?? {},
-                      R.mapWithIndex((key) => `:${key}`)
-                    );
-                    return (
-                      <ListItem key={routeName}>
-                        <ListItemText>
-                          <Typography color="primary" variant="subtitle1">
-                            {routeName}
-                          </Typography>{' '}
-                          <Typography variant="body1">
-                            {endpoint.Method} {config.REACT_APP_API_URL}
-                            {endpoint.getPath(params)}
-                          </Typography>
-                        </ListItemText>
-                      </ListItem>
-                    );
-                  })
-                )}
-              </List>
+            <Box key={apiVersionKey}>
+              <Typography color="primary" variant="h5">
+                {apiVersionKey}
+              </Typography>
+
+              {pipe(
+                apiVersionEndpoints as {
+                  [key: string]: { [key: string]: MinimalEndpointInstance };
+                },
+                R.toArray,
+                A.map(([apiNamespace, api]) => {
+                  return (
+                    <Box>
+                      <Typography variant="h6">{apiNamespace}</Typography>
+                      <List>
+                        {pipe(
+                          api,
+                          R.toArray,
+                          A.map(([routeName, endpoint]) => {
+                            const params = pipe(
+                              endpoint.Input?.Params?.props ?? {},
+                              R.mapWithIndex((key) => `:${key}`)
+                            );
+                            return (
+                              <ListItem key={apiNamespace}>
+                                <ListItemText>
+                                  <Typography
+                                    color="primary"
+                                    variant="subtitle1"
+                                    style={{ marginBottom: theme.spacing(1) }}
+                                  >
+                                    {routeName}
+                                  </Typography>{' '}
+                                  <Typography variant="body1">
+                                    {endpoint.Method} {config.REACT_APP_API_URL}
+                                    {endpoint.getPath(params)}
+                                  </Typography>
+                                </ListItemText>
+                              </ListItem>
+                            );
+                          })
+                        )}
+                      </List>
+                    </Box>
+                  );
+                })
+              )}
             </Box>
           );
         })


### PR DESCRIPTION
The `APIList` now shows all our versions of the defined API.

It still doesn't print the request and response shape per API, but I don't know if we want to have this inside the extension or have a proper swagger.io in the nearest future.

![Screenshot from 2021-11-16 16-22-51](https://user-images.githubusercontent.com/1838567/142014067-bccf0dd2-752d-4b3d-a70b-22439d7ac8d5.png)


